### PR TITLE
Fix a missing #endif

### DIFF
--- a/pkg/ctrl/ctrl_init_ctrlvar.F
+++ b/pkg/ctrl/ctrl_init_ctrlvar.F
@@ -88,8 +88,8 @@ c     _END_MASTER( mythid )
      &                        SQUEEZE_RIGHT, myThid )
 #endif
               call ctrl_set_globfld_xyz( fname(2), ivarindex, mythid)
-#endif
             endif
+#endif
             if ( ( doInitXX .AND. optimcycle.eq.0 ) .OR. doAdmTlm ) then
 #ifdef DSK_DEBUG
               WRITE(msgBuf,'(A,A)')

--- a/pkg/rw/read_rec.F
+++ b/pkg/rw/read_rec.F
@@ -488,6 +488,7 @@ c     ENDIF
 #else
      I                     iRec, myThid )
 #endif
+#endif
       RETURN
       END
 


### PR DESCRIPTION
## What changes does this PR introduce?
(Bug fix, feature, docs update, ...)
A bug fix. 

## What is the current behaviour? 
(You can also link to an open issue here)
read_rec.F misses a #endif in READ_REC_LEV_RL(). 

## What is the new behaviour 
(if this is a feature change)?
The bug is fixed.

## Does this PR introduce a breaking change? 
(What changes might users need to make in their application due to this PR?)
No.

## Other information:


## Suggested addition to `tag-index`
(To avoid unnecessary merge conflicts, please don't update `tag-index`. One of the admins will do that when merging your pull request.)